### PR TITLE
feat: add biblioteca github-automated-repos - adm exibição de projetos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "emailjs-com": "^3.2.0",
+        "github-automated-repos": "^1.2.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-scripts": "5.0.1",
@@ -8981,6 +8982,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/github-automated-repos": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/github-automated-repos/-/github-automated-repos-1.2.2.tgz",
+      "integrity": "sha512-gsaDaATXa8dx1TInWbH6qgDtQxBv6H7JouU+XZvJfq+yDdbg2JPdh5CUbLdFcT5sm78+v9VszbEwZ+sX7JDkGA=="
     },
     "node_modules/glob": {
       "version": "7.2.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "emailjs-com": "^3.2.0",
+    "github-automated-repos": "^1.2.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",

--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -1,9 +1,14 @@
 import '../css/Projects.css'
-import Surfland from '../images/Surfland.png'
-import MovieCatalog from '../images/MovieCatalog.png';
-import EmBreve from '../images/EmBreve.png';
+
+
+import { useGitHubAutomatedRepos } from "github-automated-repos";
+
+
 
 const Projects = () => {
+
+  const data = useGitHubAutomatedRepos("MatheusMMarques", "attached");
+
   return (
     <section className='project-container'>
       <div className="title-projects">
@@ -12,34 +17,32 @@ const Projects = () => {
         </h2>
       </div>
       <div className="projects">
-        <div className="project">
-          <div className="img-project">
-            <a href="https://surfland-project.vercel.app" target="_blank" rel="noopener noreferrer">
-              <img src={Surfland} className="image" />
-            </a>
-              <h6>ESTUDO DE FUNCIONALIDADES</h6>
-              <h3>SITE DE INFORMAÇÕES DE SURF</h3>
-          </div>
-        </div>
-        <div className="project">
-          <div className="img-project">
-            <a href="https://catalogmovies.vercel.app" target="_blank" rel="noopener noreferrer">
-              <img src={MovieCatalog} className="image" />
-            </a>
-            <h6>ESTUDO DE FUNCIONALIDADES</h6>
-            <h3>CATÁLOGO DE FILMES</h3>
-          </div>
-        </div>
-        <div className="project">
-          <div className="img-project">
-            <img src={EmBreve} className="image" />
-            <h6>PROJETO ACADÊMICO SENDO DESENVOLVIDO</h6>
-            <h3>EM BREVE</h3>
-          </div>
-        </div>
+        {
+
+          data.map((item) => {
+
+            return(
+              <div className="project">
+              <div className="img-project">
+                <a href={item.homepage} target="_blank" rel="noopener noreferrer">
+                  <img src={item.banner} className="image" />
+                </a>
+                <h6>{item.description }</h6>
+                <h3>{item.name}</h3>
+              </div>
+            </div>
+
+            )
+        
+          })
+        }
+
       </div>
     </section>
   )
 }
 
 export default Projects
+
+
+


### PR DESCRIPTION
- Uso da biblioteca `github-automated-repos` para automatizar a exibição de projetos GitHub com a página no ar, podendo:

❌ Remover  Projetos
✅ Adicionar Projetos
✨ Personalizar o Card com ícone de stacks e etc...

-------------------------------

📦 Acesso a documentação:   [github-automated-repos](https://github.com/DIGOARTHUR/github-automated-repos).


```mermaid
graph LR
    A[config - github-automated-repos] -- acesse seu GitHub--> B(GitHub)
    B(GitHub)--> C(repositório A)
    B(GitHub)--> D(repositório B)
    B(GitHub)-- ...--> F(...)
    C--  keyword --> E(campo topics)
    D--  keyword --> E(campo topics)
   F--  keyword --> E(campo topics)
 E--  dataGitHub--> G(🌐WebPage in Deploy)
```


